### PR TITLE
fix: macOS arm builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [macos-12, macos-latest, ubuntu-20.04, windows-latest]
+        include:
+          - platform: 'macos-latest' # for Arm based macs (M1 and above).
+            args: '--target aarch64-apple-darwin'
+          - platform: 'macos-latest' # for Intel based macs.
+            args: '--target x86_64-apple-darwin'
+          - platform: 'ubuntu-22.04' # for Linux
+            args: ''
+          - platform: 'windows-latest' # for Windows
+            args: ''
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -28,15 +36,18 @@ jobs:
 
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
+        with:
+          # These targets are only used on macos runners so it's in an `if` to slightly speed up windows and linux builds.
+          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       - name: install dependencies (ubuntu only)
-        if: matrix.platform == 'ubuntu-20.04'
+        if: matrix.platform == 'ubuntu-22.04'
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: install frontend dependencies
-        run: yarn install # change this to npm or pnpm depending on which one you use
+        run: yarn install
 
       - uses: tauri-apps/tauri-action@v0
         env:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,5 @@
   // Ignore @tailwind warnings
   "css.lint.unknownAtRules": "ignore",
   "editor.fontSize": 14,
-  "rust-analyzer.showUnlinkedFileNotification": false
+  "rust-analyzer.showUnlinkedFileNotification": false,
 }

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ cd ollama-grid-search
 
    ```sh
    cd <project root>
-   # I'm using bun to manage dependecies,
+   # I'm using bun to manage dependencies,
    # but feel free to use yarn or npm
    bun install
    ```

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,19 +13,19 @@ edition = "2021"
 tauri-build = { version = "1.5", features = [] }
 
 [dependencies]
-tauri = { version = "1.5", features = [ "fs-all", "dialog-all", "shell-open"] }
+tauri = { version = "1.6", features = [ "fs-all", "dialog-all", "shell-open"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0.79"
 thiserror = "1.0.56"
-tokio = "1.36.0"
+tokio = "1.37.0"
 url = "2.5.0"
 tauri-plugin-single-instance = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 # The feature "rustls" is added due to issues with OpenSSL on Linux releases
 # See https://github.com/tauri-apps/tauri/issues/4470#issuecomment-1170342732
 ollama-rs = { version = "0.1.9", default-features = false, features = ["rustls"] }
-chrono = "0.4.34"
-reqwest = {version = "0.12.2", features = ["blocking", "json", "rustls-tls"], default-features = false  }
+chrono = "0.4.38"
+reqwest = {version = "0.12.4", features = ["blocking", "json", "rustls-tls"], default-features = false  }
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -49,7 +49,14 @@
         "icons/128x128@2x.png",
         "icons/icon.icns",
         "icons/icon.ico"
-      ]
+      ],
+      "macOS": {
+        "entitlements": null,
+        "exceptionDomain": "",
+        "frameworks": [],
+        "providerShortName": null,
+        "signingIdentity": null
+      }
     },
     "security": {
       "csp": null


### PR DESCRIPTION
I _think_ this fixes #16 

- Bumps Linux build runner version to current stable.
- Builds for both ARM and x86 macOS separately.
- Adds basic self-signed code signing to macOS app/DMG.
- Bumps Tauri package versions to current stable.