### PR TITLE
Add config to allow concurrent inference calls (up to 5)

### DIFF
--- a/src/Atoms.ts
+++ b/src/Atoms.ts
@@ -4,6 +4,14 @@ import { atom } from "jotai";
 // Refs https://jotai.org/docs/guides/persistence
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+
+/*
+ * This implemention is taken from Jotai's persistence example, but it doesn't handle
+ *  nested values well.
+ *
+ *  If we add params to defaultConfigs, they won't initially have corresponding keys in localStorage
+ *  and the corresponding default values are not passed to the settings form.
+ */
 const atomWithLocalStorage = (key: string, initialValue: unknown) => {
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   const getInitialValue = () => {
@@ -32,6 +40,7 @@ const atomWithLocalStorage = (key: string, initialValue: unknown) => {
 // I've kept only the documented ones at default values
 const defaultConfigs: IDefaultConfigs = {
   request_timeout: 300,
+  concurrent_inferences: 1,
   server_url: "http://localhost:11434",
   system_prompt: "You are a helpful AI assistant.",
   default_options: {

--- a/src/Interfaces/index.ts
+++ b/src/Interfaces/index.ts
@@ -39,6 +39,7 @@ export type TParamIteration = {
 // Interface for the default configuration options
 export interface IDefaultConfigs {
   request_timeout: number;
+  concurrent_inferences: number;
   server_url: string;
   system_prompt: string;
   // default_options: {

--- a/src/components/results/grid-results-pane.tsx
+++ b/src/components/results/grid-results-pane.tsx
@@ -81,12 +81,15 @@ export default function GridResultsPane() {
     setIterations(localIterations);
   }, [gridParams.experiment_uuid]);
 
-  // Enable one query at a time, disable all once they've all been processed
+  // Enables a limited number of queries to run concurrently, disable all once they've all been processed
   // so new experiments can run sequentially
   const queries: any = iterations.map((params: TParamIteration, i: number) => ({
     queryKey: ["get_inference", params],
     queryFn: () => get_inference(config, params),
-    enabled: i === 0 || (i <= noCompleted && noCompleted !== iterations.length),
+    enabled:
+      i === 0 ||
+      (i <= noCompleted + (config.concurrent_inferences - 1) &&
+        noCompleted !== iterations.length),
     staleTime: 0,
     cacheTime: 0,
   }));

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -48,6 +48,7 @@ export function SettingsDialog() {
   // * default_options has to be valid JSON
   const FormSchema = z.object({
     request_timeout: z.coerce.number().min(5),
+    concurrent_inferences: z.coerce.number().min(1).max(5),
     server_url: z.string().url(),
     system_prompt: z.string(),
     default_options: z.string().refine(
@@ -169,6 +170,25 @@ export function SettingsDialog() {
                       </FormControl>
                       <FormDescription>
                         The timeout in seconds for each inference request.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+              <div className="flex flex-col gap-4">
+                <FormField
+                  control={form.control}
+                  name="concurrent_inferences"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Concurrent Inferences</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormDescription>
+                        Number of concurrent inference requests sent to the
+                        server (max. 5)
                       </FormDescription>
                       <FormMessage />
                     </FormItem>


### PR DESCRIPTION
Adds a field to settings where the user can define the number of concurrent inference calls.
Initially setting max to 5.

Read comment on Atoms.ts, regarding issues with storing nested config settings in localStorage.