### PR TITLE
Introduce nix tooling for reproducable dev envirionments

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1722415718,
+        "narHash": "sha256-5US0/pgxbMksF92k1+eOa8arJTJiPvsdZj9Dl+vJkM4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c3392ad349a5227f4a3464dce87bcc5046692fce",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,25 @@
+{
+  description = "A multi-platform desktop application to evaluate and compare LLM models, written in Rust and React.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    { nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachSystem
+      [
+        "aarch64-linux"
+        "x86_64-linux"
+      ]
+      (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          devShells.default = import ./nix/shell.nix { inherit pkgs; };
+        }
+      );
+}

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -12,7 +12,6 @@ pkgs.mkShell rec {
   nativeBuildInputs = with pkgs; [
     bun
     cargo
-    cargo
     gcc
     gnome.libsoup
     nixfmt-rfc-style

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,23 @@
+{
+  pkgs ? import <nixpkgs> { },
+}:
+let
+  inherit (pkgs) lib;
+in
+pkgs.mkShell rec {
+  CARGO_PROFILE_RELEASE_DEBUG = true;
+  LD_LIBRARY_PATH = lib.makeLibraryPath nativeBuildInputs;
+  RUST_BACKTRACE = "full";
+
+  nativeBuildInputs = with pkgs; [
+    bun
+    cargo
+    cargo
+    gcc
+    gnome.libsoup
+    nixfmt-rfc-style
+    pkg-config
+    rustc
+    webkitgtk
+  ];
+}


### PR DESCRIPTION
Added a [nix-shell](https://wiki.nixos.org/wiki/Development_environment_with_nix-shell) to the project.
This allows developers to ephemrally install pinned packages to easily get a working dev env.

- feat: added nix tooling

This only has an effect if developers use [nix](https://nixos.org/), it changes nothing about the project for anyone else.